### PR TITLE
Fix NameError: name 'name2codepoint' is not defined

### DIFF
--- a/tests/test_issue_16.py
+++ b/tests/test_issue_16.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+"""
+Simulate:
+    google_dl -s http://www.marquette.edu/maqom/ -f pdf ""
+
+"""
+from xgoogle.search import GoogleSearch
+
+
+def test_name_error_name2codepoint():
+    gs = GoogleSearch('site:http://www.marquette.edu/maqom/')
+    gs._set_filetype('pdf')
+    assert gs.get_results()

--- a/tests/test_issue_16.py
+++ b/tests/test_issue_16.py
@@ -2,7 +2,6 @@
 """
 Simulate:
     google_dl -s http://www.marquette.edu/maqom/ -f pdf ""
-
 """
 from xgoogle.search import GoogleSearch
 

--- a/xgoogle/BeautifulSoup.py
+++ b/xgoogle/BeautifulSoup.py
@@ -89,9 +89,9 @@ import types
 import re
 import sgmllib
 try:
-  from htmlentitydefs import name2codepoint
+    from html.entities import name2codepoint
 except ImportError:
-  name2codepoint = {}
+    from htmlentitydefs import name2codepoint
 
 #This hack makes Beautiful Soup able to parse XML with namespaces
 sgmllib.tagfind = re.compile('[a-zA-Z][-_.:a-zA-Z0-9]*')

--- a/xgoogle/googlesets.py
+++ b/xgoogle/googlesets.py
@@ -10,8 +10,6 @@
 
 import re
 import urllib
-import random
-from htmlentitydefs import name2codepoint
 from BeautifulSoup import BeautifulSoup
 
 from browser import Browser, BrowserError

--- a/xgoogle/realtime.py
+++ b/xgoogle/realtime.py
@@ -13,8 +13,12 @@ import re
 from datetime import datetime
 import time
 import urllib
-from htmlentitydefs import name2codepoint
 from BeautifulSoup import BeautifulSoup
+
+try:
+    from html.entities import name2codepoint
+except ImportError:
+    from htmlentitydefs import name2codepoint
 
 from search import SearchError
 from browser import Browser, BrowserError

--- a/xgoogle/search.py
+++ b/xgoogle/search.py
@@ -11,9 +11,13 @@
 
 import re
 import urllib
-import html.entities
 from bs4 import BeautifulSoup
 import nltk
+
+try:
+    from html.entities import name2codepoint
+except ImportError:
+    from htmlentitydefs import name2codepoint
 
 from xgoogle.browser import Browser, BrowserError
 

--- a/xgoogle/sponsoredlinks.py
+++ b/xgoogle/sponsoredlinks.py
@@ -11,8 +11,12 @@
 import re
 import urllib
 import random
-from htmlentitydefs import name2codepoint
 from BeautifulSoup import BeautifulSoup
+
+try:
+    from html.entities import name2codepoint
+except ImportError:
+    from htmlentitydefs import name2codepoint
 
 from browser import Browser, BrowserError
 


### PR DESCRIPTION
This handles Python 2 and 3.

As the `htmlentitydefs` module has been renamed to `html.entities` in Python 3, do you want me to update other imports?