### PR TITLE
Modify unicode character decoding

### DIFF
--- a/xgoogle/search.py
+++ b/xgoogle/search.py
@@ -358,14 +358,14 @@ class GoogleSearch(object):
         def entity_replacer(m):
             entity = m.group(1)
             if entity in name2codepoint:
-                return unichr(name2codepoint[entity])
+                return chr(name2codepoint[entity])
             else:
                 return m.group(0)
 
         def ascii_replacer(m):
             cp = int(m.group(1))
             if cp <= 255:
-                return unichr(cp)
+                return chr(cp)
             else:
                 return m.group(0)
 
@@ -626,14 +626,14 @@ class GoogleVideoSearch(object):
         def entity_replacer(m):
             entity = m.group(1)
             if entity in name2codepoint:
-                return unichr(name2codepoint[entity])
+                return chr(name2codepoint[entity])
             else:
                 return m.group(0)
 
         def ascii_replacer(m):
             cp = int(m.group(1))
             if cp <= 255:
-                return unichr(cp)
+                return chr(cp)
             else:
                 return m.group(0)
 
@@ -880,14 +880,14 @@ class GoogleImageSearch(object):
         def entity_replacer(m):
             entity = m.group(1)
             if entity in name2codepoint:
-                return unichr(name2codepoint[entity])
+                return chr(name2codepoint[entity])
             else:
                 return m.group(0)
 
         def ascii_replacer(m):
             cp = int(m.group(1))
             if cp <= 255:
-                return unichr(cp)
+                return chr(cp)
             else:
                 return m.group(0)
 
@@ -1149,14 +1149,14 @@ class GoogleFaceImageSearch(object):
         def entity_replacer(m):
             entity = m.group(1)
             if entity in name2codepoint:
-                return unichr(name2codepoint[entity])
+                return chr(name2codepoint[entity])
             else:
                 return m.group(0)
 
         def ascii_replacer(m):
             cp = int(m.group(1))
             if cp <= 255:
-                return unichr(cp)
+                return chr(cp)
             else:
                 return m.group(0)
 


### PR DESCRIPTION
I have modified unicode character decoding to be compatible with Python 3.x. Indeed, Python 3.x does not have unichr() method because Python 2.x and Python 3.x do not handle it the same way.

> In Python 3, there's no difference between unicode and normal strings anymore. Only between unicode strings and binary data. So the developers finally removed the unichr function in favor of a common chr which now does what the old unichr did.

